### PR TITLE
Implement pgvector-dotnet

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.11" />
     <PackageVersion Include="OctoKit" Version="8.1.1" />
     <PackageVersion Include="OpenAI" Version="1.7.2" />
+    <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.1.2" />
     <PackageVersion Include="refit" Version="7.0.0" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="7.0.0" />
   </ItemGroup>

--- a/docker/postgres/1-init-user-and-db.sh
+++ b/docker/postgres/1-init-user-and-db.sh
@@ -2,7 +2,5 @@
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-    CREATE USER aidemouser WITH PASSWORD 'mtUvGABu';
-    CREATE DATABASE aidemo;
-    GRANT ALL PRIVILEGES ON DATABASE aidemo TO aidemo;
+    CREATE DATABASE aidemodb;
 EOSQL

--- a/docker/postgres/2-extensions.sh
+++ b/docker/postgres/2-extensions.sh
@@ -4,8 +4,8 @@ set -e
 # Only a superuser can create extensions, so we need to do this during initialization.
 # Unfortunately that means that database migrations can't add extensions.
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "aidemo" <<-EOSQL
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "aidemodb" <<-EOSQL
     CREATE EXTENSION IF NOT EXISTS "citext";
-    CREATE EXTENSION IF NOT EXISTS "postgis";
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    CREATE EXTENSION IF NOT EXISTS "vector";
 EOSQL

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,5 +1,5 @@
-ARG VERSION=14-3.2
-FROM postgis/postgis:$VERSION-alpine
+FROM ankane/pgvector
 
 COPY 1-init-user-and-db.sh /docker-entrypoint-initdb.d/
 COPY 2-extensions.sh /docker-entrypoint-initdb.d/
+

--- a/src/AIDemoWeb/AIDemoContextFactory.cs
+++ b/src/AIDemoWeb/AIDemoContextFactory.cs
@@ -1,6 +1,7 @@
 using Haack.AIDemoWeb.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Pgvector.EntityFrameworkCore;
 
 namespace AIDemoWeb.Entities;
 
@@ -22,6 +23,7 @@ public class AIDemoContextFactory : IDesignTimeDbContextFactory<AIDemoContext>
             .UseNpgsql(configuration.GetConnectionString(AIDemoContext.ConnectionStringName),
                 options =>
                 {
+                    options.UseVector();
                     options.MigrationsAssembly("AIDemoWeb");
                 });
         return new AIDemoContext(optionsBuilder.Options);

--- a/src/AIDemoWeb/Entities/UserFact.cs
+++ b/src/AIDemoWeb/Entities/UserFact.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using Pgvector;
 
 namespace Haack.AIDemoWeb.Entities;
 
@@ -25,7 +26,7 @@ public class UserFact
     /// </remarks>
     #pragma warning disable CA1002
     [Column(TypeName = "vector(1536 )")]
-    public required List<float> Embeddings { get; init; }
+    public required Vector Embeddings { get; init; }
     #pragma warning restore CA1002
 
     /// <summary>

--- a/src/AIDemoWeb/Entities/UserFact.cs
+++ b/src/AIDemoWeb/Entities/UserFact.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace Haack.AIDemoWeb.Entities;
 
 /// <summary>
@@ -18,7 +20,11 @@ public class UserFact
     /// <summary>
     /// Embeddings for the fact.
     /// </summary>
+    /// <remarks>
+    /// The output dimensions for text-embedding-ada-002 is 1536.
+    /// </remarks>
     #pragma warning disable CA1002
+    [Column(TypeName = "vector(1536 )")]
     public required List<float> Embeddings { get; init; }
     #pragma warning restore CA1002
 

--- a/src/AIDemoWeb/Library/ChatFunctions/RetrieveUserFactFunction.cs
+++ b/src/AIDemoWeb/Library/ChatFunctions/RetrieveUserFactFunction.cs
@@ -50,7 +50,7 @@ public class RetrieveUserFactFunction : ChatFunction<RetrieveUserFactArguments, 
             .Select(fact => new
             {
                 Fact = fact,
-                Similarity = fact.Embeddings.CosineSimilarity(embeddings)
+                Similarity = fact.Embeddings!.ToArray().CosineSimilarity(embeddings)
             })
             .Where(candidate => candidate.Similarity > 0.8)
             .OrderByDescending(candidate => candidate.Similarity)

--- a/src/AIDemoWeb/Library/ChatFunctions/RetrieveUserFactFunction.cs
+++ b/src/AIDemoWeb/Library/ChatFunctions/RetrieveUserFactFunction.cs
@@ -6,6 +6,7 @@ using Haack.AIDemoWeb.Library;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using OpenAIDemo.Hubs;
+using Pgvector.EntityFrameworkCore;
 
 namespace Serious.ChatFunctions;
 
@@ -36,38 +37,33 @@ public class RetrieveUserFactFunction : ChatFunction<RetrieveUserFactArguments, 
         // Calculate the embedding for the question.
         var embeddings = await _client.GetEmbeddingsAsync(arguments.Question, cancellationToken);
 
-        var user = await _db.Users
-            .Include(u => u.Facts)
-            .FirstOrDefaultAsync(u => u.Name == arguments.Username, cancellationToken);
-
-        if (user is null)
+        if (embeddings is null)
         {
             return null;
         }
 
-        // Grab the item with the highest cosine similarity.
-        var facts = user.Facts
-            .Select(fact => new
+        // Cosine similarity == 1 - Cosine Distance.
+        var facts = await _db.UserFacts
+            .Where(f => f.User.Name == arguments.Username)
+            .Select(f => new
             {
-                Fact = fact,
-                Similarity = fact.Embeddings!.ToArray().CosineSimilarity(embeddings)
+                Fact = f,
+                Distance = f.Embeddings.CosineDistance(embeddings),
             })
-            .Where(candidate => candidate.Similarity > 0.8)
-            .OrderByDescending(candidate => candidate.Similarity)
-            .ToList();
+            .Where(x => x.Distance <= 0.25)
+            .OrderBy(x => x.Distance)
+            .ToListAsync(cancellationToken);
 
         if (facts.Count > 0)
         {
-            var factSummary = string.Join("\n", facts.Select(f => $"Similarity: {f.Similarity}\tFact: {f.Fact.Content} Justification: {f.Fact.Justification} Source: {f.Fact.Source}"));
+            var factSummary = string.Join("\n", facts.Select(f => $"Similarity: {1.0 - f.Distance} Fact: {f.Fact.Content} Justification: {f.Fact.Justification} Source: {f.Fact.Source}"));
 
             await SendThought($"I have {facts.Count.ToQuantity("answer")} to that question\n\n{factSummary}");
             var answer = string.Join("\n", facts.Select(a => a.Fact.Content));
             return new UserFactResult(answer);
         }
-        else
-        {
-            return new UserFactResult("I do not know");
-        }
+
+        return new UserFactResult("I do not know");
 
         async Task SendThought(string thought)
             => await _hubContext.Clients.All.SendAsync("thoughtReceived", thought, cancellationToken);

--- a/src/AIDemoWeb/Library/ChatFunctions/StoreUserFactFunction.cs
+++ b/src/AIDemoWeb/Library/ChatFunctions/StoreUserFactFunction.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using Azure.AI.OpenAI;
 using Haack.AIDemoWeb.Entities;
 using Microsoft.EntityFrameworkCore;
+using Pgvector;
 
 namespace Serious.ChatFunctions;
 
@@ -46,7 +47,7 @@ public class StoreUserFactFunction : ChatFunction<UserFactArguments, object>
                 User = user,
                 UserId = user.Id,
                 Content = arguments.Fact,
-                Embeddings = embeddings,
+                Embeddings = new Vector(embeddings),
                 Justification = arguments.Justification,
                 Source = source,
             });
@@ -56,7 +57,7 @@ public class StoreUserFactFunction : ChatFunction<UserFactArguments, object>
         return null; // No need to respond.
     }
 
-    async Task<List<float>> GetEmbeddingsAsync(UserFactArguments arguments, CancellationToken cancellationToken)
+    async Task<float[]> GetEmbeddingsAsync(UserFactArguments arguments, CancellationToken cancellationToken)
     {
         try
         {
@@ -66,7 +67,7 @@ public class StoreUserFactFunction : ChatFunction<UserFactArguments, object>
                 var embedding = response.Value.Data;
                 if (embedding is { Count: > 0 })
                 {
-                    return embedding[0].Embedding.ToList();
+                    return embedding[0].Embedding.ToArray();
                 }
             }
         }
@@ -75,7 +76,7 @@ public class StoreUserFactFunction : ChatFunction<UserFactArguments, object>
 #pragma warning restore CA1031
         {
         }
-        return new List<float>();
+        return Array.Empty<float>();
     }
 }
 

--- a/src/AIDemoWeb/Library/OpenAIClientAccessor.cs
+++ b/src/AIDemoWeb/Library/OpenAIClientAccessor.cs
@@ -3,6 +3,7 @@ using Azure.AI.OpenAI;
 using Haack.AIDemoWeb.Library.Clients;
 using Haack.AIDemoWeb.Startup.Config;
 using Microsoft.Extensions.Options;
+using Pgvector;
 
 namespace Serious;
 
@@ -54,7 +55,7 @@ public class OpenAIClientAccessor
     /// </summary>
     /// <param name="prompt">The prompt for this embeddings request.</param>
     /// <param name="cancellationToken">The cancellation token to use.</param>
-    public async Task<List<float>> GetEmbeddingsAsync(string prompt, CancellationToken cancellationToken)
+    public async Task<Vector?> GetEmbeddingsAsync(string prompt, CancellationToken cancellationToken)
     {
         var response = await GetEmbeddingsAsync(new EmbeddingsOptions(prompt), cancellationToken);
         if (response.HasValue)
@@ -62,11 +63,11 @@ public class OpenAIClientAccessor
             var embedding = response.Value.Data;
             if (embedding is { Count: > 0 })
             {
-                return embedding[0].Embedding.ToList();
+                return new Vector(embedding[0].Embedding.ToArray());
             }
         }
 
-        return new List<float>();
+        return null;
     }
 
     public async Task<List<OpenAIEntity>> GetModelsAsync(CancellationToken cancellationToken = default)

--- a/src/AIDemoWeb/Migrations/20231107172252_AddVectorColumn.Designer.cs
+++ b/src/AIDemoWeb/Migrations/20231107172252_AddVectorColumn.Designer.cs
@@ -2,6 +2,7 @@
 using Haack.AIDemoWeb.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -10,9 +11,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Haack.AIDemoWeb.Migrations
 {
     [DbContext(typeof(AIDemoContext))]
-    partial class AIDemoContextModelSnapshot : ModelSnapshot
+    [Migration("20231107172252_AddVectorColumn")]
+    partial class AddVectorColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AIDemoWeb/Migrations/20231107172252_AddVectorColumn.cs
+++ b/src/AIDemoWeb/Migrations/20231107172252_AddVectorColumn.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Haack.AIDemoWeb.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVectorColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .Annotation("Npgsql:PostgresExtension:vector", ",,")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "Embeddings",
+                table: "UserFacts",
+                type: "vector(1536 )",
+                nullable: false,
+                oldClrType: typeof(List<float>),
+                oldType: "real[]");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,")
+                .OldAnnotation("Npgsql:PostgresExtension:vector", ",,");
+
+            migrationBuilder.AlterColumn<List<float>>(
+                name: "Embeddings",
+                table: "UserFacts",
+                type: "real[]",
+                nullable: false,
+                oldClrType: typeof(byte[]),
+                oldType: "vector(1536 )");
+        }
+    }
+}

--- a/src/AIDemoWeb/Migrations/AIDemoContextModelSnapshot.cs
+++ b/src/AIDemoWeb/Migrations/AIDemoContextModelSnapshot.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Pgvector;
 
 #nullable disable
 
@@ -55,7 +56,7 @@ namespace Haack.AIDemoWeb.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<byte[]>("Embeddings")
+                    b.Property<Vector>("Embeddings")
                         .IsRequired()
                         .HasColumnType("vector(1536 )");
 

--- a/src/AIDemoWeb/Pages/Demos/Users.cshtml
+++ b/src/AIDemoWeb/Pages/Demos/Users.cshtml
@@ -27,7 +27,12 @@
                                 <td>@fact.Content</td>
                                 <td>@fact.Source</td>
                                 <td>@fact.Justification</td>
-                                <td>@string.Join(",", fact.Embeddings)</td>
+                                <td>
+                                    @fact.Embeddings.Count
+                                    <details>
+                                        @string.Join(",", fact.Embeddings)
+                                    </details>
+                                </td>
                             </tr>
                         }
                     </tbody>

--- a/src/AIDemoWeb/Pages/Demos/Users.cshtml
+++ b/src/AIDemoWeb/Pages/Demos/Users.cshtml
@@ -28,7 +28,7 @@
                                 <td>@fact.Source</td>
                                 <td>@fact.Justification</td>
                                 <td>
-                                    @fact.Embeddings.Count
+                                    @fact.Embeddings.ToArray().Length
                                     <details>
                                         @string.Join(",", fact.Embeddings)
                                     </details>

--- a/src/AiDemoWeb/AiDemoWeb.csproj
+++ b/src/AiDemoWeb/AiDemoWeb.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="OctoKit" />
+    <PackageReference Include="Pgvector.EntityFrameworkCore" />
     <PackageReference Include="refit" />
     <PackageReference Include="Refit.HttpClientFactory" />
   </ItemGroup>

--- a/src/AiDemoWeb/Entities/AIDemoContext.cs
+++ b/src/AiDemoWeb/Entities/AIDemoContext.cs
@@ -1,4 +1,3 @@
-using Haack.AIDemoWeb.Migrations;
 using Microsoft.EntityFrameworkCore;
 
 namespace Haack.AIDemoWeb.Entities;
@@ -23,7 +22,8 @@ public class AIDemoContext : DbContext
         // IMPORTANT! Custom crap goes AFTER the call to base.OnModelCreating
         //
 
-        modelBuilder.HasPostgresExtension("citext");
+        modelBuilder.HasPostgresExtension("citext"); // case insensitive text
+        modelBuilder.HasPostgresExtension("vector"); // pgvector for vector similarity support.
 
         // User names must be unique.
         modelBuilder.Entity<User>()

--- a/src/AiDemoWeb/Startup/ServiceExtensions.cs
+++ b/src/AiDemoWeb/Startup/ServiceExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Refit;
 using Serious;
-
+using Pgvector.EntityFrameworkCore;
 namespace Haack.AIDemoWeb.Startup;
 
 public static class ServiceExtensions
@@ -41,7 +41,11 @@ public static class ServiceExtensions
 #endif
         options.ConfigureWarnings(warnings => warnings.Ignore(CoreEventId.NavigationBaseIncludeIgnored));
 
-        options.UseNpgsql(connectionString, o => o.MigrationsAssembly("AIDemoWeb"));
+        options.UseNpgsql(connectionString, o =>
+        {
+            o.UseVector();
+            o.MigrationsAssembly("AIDemoWeb");
+        });
     }
 
     public static void AddAuthentication(this IServiceCollection services, IConfiguration configuration)

--- a/src/AiDemoWeb/packages.lock.json
+++ b/src/AiDemoWeb/packages.lock.json
@@ -101,6 +101,16 @@
         "resolved": "8.1.1",
         "contentHash": "qrRUuJSkmCht+kG4Gf01jtbzNhYbUssy99VsUYlk9d/Z3vFCRpLn7Iulh3V3OWhpWaeHfHUKTMx9VbOB1uoo/A=="
       },
+      "Pgvector.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[0.1.2, )",
+        "resolved": "0.1.2",
+        "contentHash": "7HfV70Un5qxgIBFVzC+Lv66nlRdp2H6apYIiPUSGELYXY+DwbfJWCuLOA+ixLK4pSstKJtRVruSLcienfIL17w==",
+        "dependencies": {
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "7.0.0",
+          "Pgvector": "0.1.4"
+        }
+      },
       "Refit": {
         "type": "Direct",
         "requested": "[7.0.0, )",
@@ -355,6 +365,14 @@
         "contentHash": "TAqvwRnm3NJ0QvN7cvu6geJkbI0XPzGVRElVY5hF4gsgA+BnE12x6GM1TLhdeq+7ZKvvo3BD8jXKnXmr3tvdEw==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+        }
+      },
+      "Pgvector": {
+        "type": "Transitive",
+        "resolved": "0.1.4",
+        "contentHash": "OWwNQ9W3z+4JFp0mnv7Av6HvY+f473E2rSUeVoMtcddbbTFBBYcmrX396HiMlWcg698lwQeZogcbXDdRese5aA==",
+        "dependencies": {
+          "Npgsql": "7.0.0"
         }
       },
       "System.CodeDom": {


### PR DESCRIPTION
This now uses the pgvector extension to query for similar embeddings rather than pulling all facts to the client and doing the search there. This should be much more efficient!